### PR TITLE
Add some extra context for transforms and support single file gobbling

### DIFF
--- a/lib/builtins/map.js
+++ b/lib/builtins/map.js
@@ -5,10 +5,10 @@ var path = require( 'path' ),
 	sander = require( 'sander' ),
 	link = require( '../file/link' ),
 	assign = require( '../utils/assign' ),
+	makeLog = require( '../utils/makeLog' ),
+	config = require( '../config' ),
 	compareBuffers = require( '../utils/compareBuffers' ),
 	extractLocationInfo = require( '../utils/extractLocationInfo' );
-
-
 
 module.exports = function map ( inputdir, outputdir, options ) {
 	var transformation = this;
@@ -74,7 +74,9 @@ module.exports = function map ( inputdir, outputdir, options ) {
 								src: srcpath,
 								dest: path.join( outputdir, destname ),
 								filename: filename,
-								mapname: mapname
+								mapname: mapname,
+								log: transformation.log,
+								env: config.env
 							};
 
 							try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var getNode = require( './utils/getNode' ),
-	config = require( './config' );
+	config = require( './config' ),
+	sander = require( 'sander' );
 
 var gobble = function ( inputs, options ) {
 	return getNode( inputs, options );
@@ -20,5 +21,7 @@ gobble.cwd = function () {
 
 	return config.cwd;
 };
+
+gobble.sander = sander;
 
 module.exports = gobble;

--- a/lib/nodes/Source.js
+++ b/lib/nodes/Source.js
@@ -3,6 +3,8 @@ var fs = require( 'fs' ),
 	chokidar = require( 'graceful-chokidar' ),
 	debounce = require( 'debounce' ),
 	Node = require( './Node' ),
+	_path = require( 'path' ),
+	uid = require( '../utils/uid' ),
 
 	Promise = sander.Promise,
 
@@ -20,7 +22,10 @@ module.exports = Node.extend({
 			stats = sander.statSync( node.dir );
 
 			if ( !stats.isDirectory() ) {
-				throw new Error( node.dir + ' is not a directory' );
+				node.file = dir;
+				node.dir = _path.resolve( process.env.GOBBLE_TMP_DIR || '.gobble-tmp', uid( 'file-watch' ) );
+				node.targetFile = _path.resolve( node.dir, _path.basename( node.file ) );
+				sander.mkdirSync( node.dir );
 			}
 		} catch ( err ) {
 			if ( err.code === 'ENOENT' ) {
@@ -43,7 +48,7 @@ module.exports = Node.extend({
 	},
 
 	start: function () {
-		var node = this, relay, options, changes = [];
+		var node = this, relay, options, watchError, changes = [];
 
 		if ( node._active || node.static ) {
 			return;
@@ -77,7 +82,7 @@ module.exports = Node.extend({
 			});
 		});
 
-		node._watcher.on( 'error', function ( err ) {
+		watchError = function ( err ) {
 			var gobbleError;
 
 			gobbleError = new GobbleError({
@@ -87,11 +92,26 @@ module.exports = Node.extend({
 			});
 
 			node.emit( 'error', gobbleError );
-		});
+		};
+
+		node._watcher.on( 'error', watchError );
+
+		if ( node.file ) {
+			node._fileWatcher = chokidar.watch( node.file, options );
+
+			node._fileWatcher.on( 'change', function () {
+				sander.link( node.file ).to( node.targetFile );
+			});
+
+			node._fileWatcher.on( 'error', watchError );
+		}
 	},
 
 	stop: function () {
 		this._watcher.close();
+		if ( this._fileWatcher ) {
+			this._fileWatcher.close();
+		}
 		this._active = false;
 	},
 

--- a/lib/nodes/Transformer.js
+++ b/lib/nodes/Transformer.js
@@ -8,6 +8,8 @@ var path = require( 'path' ),
 	GobbleError = require( '../utils/GobbleError' ),
 	assign = require( '../utils/assign' ),
 	uid = require( '../utils/uid' ),
+	makeLog = require( '../utils/makeLog' ),
+	config = require( '../config' ),
 	warnOnce = require( '../utils/warnOnce' ),
 	extractLocationInfo = require( '../utils/extractLocationInfo' );
 
@@ -45,7 +47,10 @@ module.exports = Node.extend({
 		if ( !node._ready ) {
 			transformation = {
 				node: node,
-				cachedir: path.resolve( session.config.gobbledir, node.id, '.cache' )
+				cachedir: path.resolve( session.config.gobbledir, node.id, '.cache' ),
+				log: makeLog( node ),
+				env: config.env,
+				sander: sander
 			};
 
 			node._abort = function () {

--- a/lib/utils/makeLog.js
+++ b/lib/utils/makeLog.js
@@ -1,0 +1,12 @@
+module.exports = function makeLog ( node, event ) {
+  if ( !event ) event = 'info';
+
+  return function log ( details ) {
+    // it's a string that may be formatted
+    if ( typeof details === 'string' ) {
+      node.emit( event, { progressIndicator: true, message: details, parameters: Array.prototype.slice.call( arguments, 1 ) } );
+    } else { // otherwise, pass through
+      node.emit( event, details );
+    }
+  };
+};


### PR DESCRIPTION
**There are no tests (yet?)** - RFC

This is a combo of #23 and #24.

## #23 Single file
If the gobbled target is a single file, the Source creates a temporary directory and assigns it as the `dir`. A watch is placed on the `dir` as usual, but one is also set on the file. When the file changes, sander copies the new file into the temp dir, which triggers the watch on `dir` as usual.

I wasn't really sure where to put the temp dir, since there could be one of three different `.gobble*` directories in play during any given run. The `session.config` is not available at Source creation time, so I went with `.gobble-tmp` for now.

## #24 Context
There are a couple of additions to the contexts for transforms:
* It adds `env` to the context with which transforms are called.
* It also adds a log function that triggers an `info` event to be emitted for the cli (or whatever, I suppose) to log. It has a plain text/format overload along with the straight pass-through object flavor. The text overload keeps the progress pills popping.
* It adds sander to the context for transforms and to the main gobble export. Sander is so darned convenient for moving files about, which a lot of directory transforms and gobblefiles need to do. Exposing gobbles sander makes it that much more convenient.

There is a PR on gobble-cli to help with logging. gobblejs/gobble-cli#5