### PR TITLE
Allow transforms to filter accepted files with regexps too

### DIFF
--- a/lib/builtins/map.js
+++ b/lib/builtins/map.js
@@ -6,8 +6,8 @@ var path = require( 'path' ),
 	link = require( '../file/link' ),
 	assign = require( '../utils/assign' ),
 	compareBuffers = require( '../utils/compareBuffers' ),
-	extractLocationInfo = require( '../utils/extractLocationInfo' );
-
+	extractLocationInfo = require( '../utils/extractLocationInfo' ),
+	isRegExp = require( '../utils/is' ).isRegExp;
 
 
 module.exports = function map ( inputdir, outputdir, options ) {
@@ -35,7 +35,7 @@ module.exports = function map ( inputdir, outputdir, options ) {
 
 				// If this mapper only accepts certain extensions, and this isn't
 				// one of them, just copy the file
-				if ( options.accept && !~options.accept.indexOf( ext ) ) {
+				if ( skip( options, ext, filename ) ) {
 					return sander.link( srcpath ).to( destpath );
 				}
 
@@ -172,3 +172,23 @@ module.exports = function map ( inputdir, outputdir, options ) {
 		}, reject );
 	});
 };
+
+function skip(options, ext, filename) {
+	var filter, i, flt;
+
+	if ( filter = options.accept ) {
+		for ( i=0; i<filter.length; i++ ) {
+			flt = filter[i];
+
+			if ( typeof flt === 'string' && flt === ext ) {
+				return false;
+			} else if ( isRegExp( flt ) && flt.test( filename ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	return false;
+}

--- a/lib/nodes/Node.js
+++ b/lib/nodes/Node.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require( 'eventemitter2' ).EventEmitter2,
 	GobbleError = require( '../utils/GobbleError' ),
 	assign = require( '../utils/assign' ),
 	warnOnce = require( '../utils/warnOnce' ),
+	isRegExp = require( '../utils/is' ).isRegExp,
 
 	serve = require( './serve' ),
 	build = require( './build' ),
@@ -149,7 +150,7 @@ Node.prototype = assign( Object.create( EventEmitter2.prototype ), {
 				userOptions: assign( {}, userOptions )
 			});
 
-			if ( typeof options.accept === 'string' ) {
+			if ( typeof options.accept === 'string' || isRegExp( options.accept ) ) {
 				options.accept = [ options.accept ];
 			}
 

--- a/lib/utils/is.js
+++ b/lib/utils/is.js
@@ -1,0 +1,5 @@
+function isRegExp ( what ) {
+  return Object.prototype.toString.call( what ) === '[object RegExp]';
+}
+
+module.exports.isRegExp = isRegExp;

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -124,6 +124,26 @@ module.exports = function () {
 			});
 		});
 
+		it( 'should allow file transforms to filter with a RegExp', function () {
+			var count = 0, source = gobble( 'tmp/foo' ), task;
+
+			function checkFilter( input ) {
+				count++;
+				return input;
+			}
+			checkFilter.defaults = {
+				accept: /foo\.md/
+			}
+
+			task = source.transform( checkFilter ).build({
+				dest: 'tmp/output'
+			});
+
+			return task.then( function () {
+				assert.equal( count, 1 );
+			});
+		});
+
 		it( 'should gracefully handle source nodes that appear twice (#19)', function ( done ) {
 			var timesToRun = 100;
 


### PR DESCRIPTION
I have a file transform that compiles a bunch of semi-html files into specialized js functions. I would like to be able to differentiate them from other html files nearby by having a two-layer extension (eg `.foo.html`) so that they still get syntax highlighting at edit time. As it stands `accept` for functions only supports string extensions, which can only be one level deep. This adds support for regular expressions to appear in `accepts` lists too.