### PR TITLE
delete unwanted options from map transforms

### DIFF
--- a/src/builtins/map.js
+++ b/src/builtins/map.js
@@ -67,6 +67,9 @@ export default function map ( inputdir, outputdir, options ) {
 							};
 
 							let transformOptions = assign( {}, options.fn.defaults, options.userOptions );
+
+							delete transformOptions.accept;
+							delete transformOptions.ext;
 							result = options.fn.call( context, data.toString(), transformOptions );
 						} catch ( e ) {
 							let err = createTransformError( e, src, filename, this.node );

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -333,6 +333,28 @@ module.exports = function () {
 				done();
 			});
 		});
+
+		it( 'should delete unwanted options from map transformers', function ( done ) {
+			var source = gobble( 'tmp/foo' );
+
+			task = source.transform( checkOptions ).serve();
+
+			function checkOptions ( code, options ) {
+				assert.ok( !options.accept );
+				assert.ok( !options.ext );
+
+				return code;
+			}
+
+			checkOptions.defaults = {
+				accept: '.md',
+				ext: '.txt'
+			};
+
+			task.on( 'built', function () {
+				done();
+			});
+		});
 	});
 
 


### PR DESCRIPTION
This relates to https://github.com/babel/gobble-babel/issues/2 - a map transform can specify default options like so:

```js
function myTransform ( code, options ) {
  // ...
}

myTransform.defaults = {
  // we need these for some map transforms, but we don't want to
  // pass them through to the underlying library or otherwise use
  // it inside the transform
  accept: [ '.yaml', '.json' ],
  ext: '.js',

  // we probably *do* want this to be passed through
  somethingElse: 42
};
```

This changes the behaviour such that `ext` and `accept` are removed from the options object passed into the transform. (This might seem slightly arbitrary, but map transforms are already a layer of opinionation on top of 'standard' transforms, and the convenience outweighs the potential pain, IMO.)