### PR TITLE
more robust invalidation

### DIFF
--- a/src/builtins/map.js
+++ b/src/builtins/map.js
@@ -7,6 +7,7 @@ import assign from '../utils/assign';
 import config from '../config';
 import extractLocationInfo from '../utils/extractLocationInfo';
 import { isRegExp } from '../utils/is';
+import { ABORTED } from '../utils/signals';
 
 const SOURCEMAP_COMMENT = /\/\/#\s*sourceMappingURL=[^\s]+/;
 
@@ -53,7 +54,7 @@ export default function map ( inputdir, outputdir, options ) {
 				// Otherwise, we queue up a transformation
 				return queue.add( ( fulfil, reject ) => {
 					if ( this.aborted ) {
-						return reject( this.aborted );
+						return reject( ABORTED );
 					}
 
 					// Create context object - this will be passed to transformers
@@ -71,7 +72,7 @@ export default function map ( inputdir, outputdir, options ) {
 					return readFile( src ).then( buffer => buffer.toString( transformOptions.sourceEncoding ) ).then( data => {
 						var result, code, map, mappath;
 
-						if ( this.aborted ) return reject( this.aborted );
+						if ( this.aborted ) return reject( ABORTED );
 
 						try {
 							result = options.fn.call( context, data, transformOptions );

--- a/src/builtins/map.js
+++ b/src/builtins/map.js
@@ -53,7 +53,7 @@ export default function map ( inputdir, outputdir, options ) {
 				// Otherwise, we queue up a transformation
 				return queue.add( ( fulfil, reject ) => {
 					if ( this.aborted ) {
-						return reject();
+						return reject( this.aborted );
 					}
 
 					// Create context object - this will be passed to transformers
@@ -71,7 +71,7 @@ export default function map ( inputdir, outputdir, options ) {
 					return readFile( src ).then( buffer => buffer.toString( transformOptions.sourceEncoding ) ).then( data => {
 						var result, code, map, mappath;
 
-						if ( this.aborted ) return reject();
+						if ( this.aborted ) return reject( this.aborted );
 
 						try {
 							result = options.fn.call( context, data, transformOptions );

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -12,6 +12,7 @@ import serve from './serve';
 import build from './build';
 import watch from './watch';
 import { isRegExp } from '../utils/is';
+import { ABORTED } from '../utils/signals';
 
 export default class Node extends EventEmitter2 {
 	constructor () {
@@ -82,7 +83,7 @@ export default class Node extends EventEmitter2 {
 		}
 
 		function handleError ( e ) {
-			if ( e.code === 'BUILD_INVALIDATED' ) {
+			if ( e === ABORTED ) {
 				// these happen shortly after an invalidation,
 				// we can ignore them
 				return;

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -49,6 +49,20 @@ export default class Node extends EventEmitter2 {
 			watchTask.emit( 'info', details );
 		});
 
+		node.on( 'invalidate', changes => {
+			// A node can depend on the same source twice, which will result in
+			// simultaneous rebuilds unless we defer it to the next tick
+			if ( !buildScheduled ) {
+				buildScheduled = true;
+				watchTask.emit( 'info', {
+					code: 'BUILD_INVALIDATED',
+					changes: changes
+				});
+
+				process.nextTick( build );
+			}
+		});
+
 		node.on( 'error', handleError );
 
 		function build () {
@@ -68,22 +82,10 @@ export default class Node extends EventEmitter2 {
 		}
 
 		function handleError ( e ) {
-			if ( e.code === 'MERGE_ABORTED' ) {
+			if ( e.code === 'BUILD_INVALIDATED' ) {
+				// these happen shortly after an invalidation,
+				// we can ignore them
 				return;
-			}
-
-			if ( e.code === 'INVALIDATED' ) {
-				// A node can depend on the same source twice, which will result in
-				// simultaneous rebuilds unless we defer it to the next tick
-				if ( !buildScheduled ) {
-					buildScheduled = true;
-					watchTask.emit( 'info', {
-						code: 'BUILD_INVALIDATED',
-						changes: e.changes
-					});
-
-					process.nextTick( build );
-				}
 			} else {
 				watchTask.emit( 'error', e );
 			}

--- a/src/nodes/Source.js
+++ b/src/nodes/Source.js
@@ -101,19 +101,6 @@ export default class Source extends Node {
 			});
 		});
 
-		// TODO
-		/*watchError = err => {
-			var gobbleError = new GobbleError({
-				message: 'error watching ' + this.dir + ': ' + err.message,
-				code: 'SOURCE_ERROR',
-				original: err
-			});
-
-			this.emit( 'error', gobbleError );
-		};
-
-		this._watcher.on( 'error', watchError );*/
-
 		if ( this.file ) {
 			this._fileWatcher = watch( this.file, options );
 

--- a/src/nodes/Source.js
+++ b/src/nodes/Source.js
@@ -70,12 +70,6 @@ export default class Source extends Node {
 		}
 
 		relay = debounce( () => {
-			var error = new GobbleError({
-				code: 'INVALIDATED',
-				message: 'build invalidated',
-				changes: changes
-			});
-
 			this.changes = changes.map( change => {
 				let result = {
 					file: relative( this.dir, change.path )
@@ -88,7 +82,7 @@ export default class Source extends Node {
 				return result;
 			});
 
-			this.emit( 'error', error );
+			this.emit( 'invalidate', changes );
 			changes = [];
 		}, 100 );
 
@@ -107,7 +101,8 @@ export default class Source extends Node {
 			});
 		});
 
-		watchError = err => {
+		// TODO
+		/*watchError = err => {
 			var gobbleError = new GobbleError({
 				message: 'error watching ' + this.dir + ': ' + err.message,
 				code: 'SOURCE_ERROR',
@@ -117,7 +112,7 @@ export default class Source extends Node {
 			this.emit( 'error', gobbleError );
 		};
 
-		this._watcher.on( 'error', watchError );
+		this._watcher.on( 'error', watchError );*/
 
 		if ( this.file ) {
 			this._fileWatcher = watch( this.file, options );

--- a/src/nodes/Transformer.js
+++ b/src/nodes/Transformer.js
@@ -12,6 +12,7 @@ import makeLog from '../utils/makeLog';
 import config from '../config';
 import warnOnce from '../utils/warnOnce';
 import extractLocationInfo from '../utils/extractLocationInfo';
+import { ABORTED } from '../utils/signals';
 
 export default class Transformer extends Node {
 	constructor ( input, transformer, options, id ) {
@@ -51,11 +52,7 @@ export default class Transformer extends Node {
 
 			this._abort = ( changes ) => {
 				this._ready = null;
-				transformation.aborted = new GobbleError({
-					changes,
-					code: 'BUILD_INVALIDATED',
-					message: 'build invalidated'
-				});
+				transformation.aborted = true;
 			};
 
 			outputdir = resolve( session.config.gobbledir, this.id, '' + this.counter++ );
@@ -81,7 +78,7 @@ export default class Transformer extends Node {
 							called = true;
 
 							if ( transformation.aborted ) {
-								reject( transformation.aborted );
+								reject( ABORTED );
 							}
 
 							else if ( err ) {

--- a/src/nodes/Transformer.js
+++ b/src/nodes/Transformer.js
@@ -82,6 +82,7 @@ export default class Transformer extends Node {
 
 								let gobbleError = new GobbleError({
 									message: 'transformation failed',
+									inputdir, outputdir,
 									id: this.id,
 									code: 'TRANSFORMATION_FAILED',
 									original: err,

--- a/src/utils/signals.js
+++ b/src/utils/signals.js
@@ -1,0 +1,1 @@
+export const ABORTED = { aborted: true };

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -487,6 +487,7 @@ module.exports = function () {
 						type: 'change',
 						path: 'tmp/foo/foo.md'
 					});
+					shouldInvalidate = false;
 				}
 
 				return Math.random();

--- a/test/utils/simulateChange.js
+++ b/test/utils/simulateChange.js
@@ -1,10 +1,7 @@
 var path = require( 'path' );
 
 module.exports = function simulateChange ( source, change ) {
-	source.emit( 'error', {
-		name: 'GobbleError',
-		code: 'INVALIDATED',
-		message: 'build invalidated',
+	source.emit( 'invalidate', {
 		changes: [{
 			type: change.type,
 			path: path.resolve( change.path )


### PR DESCRIPTION
This fixes #42, and introduces a more robust approach to build invalidation. Rather than treating invalidation (i.e. debounced file changes) as an error, there's a special `invalidate` event which triggers a rebuild (assuming we're watching the tree, that is). Transformer node `ready` promises will be rejected if a source is invalidated during the transformation; the `ABORTED` signal will propagate down the tree and be harmlessly ignored by the watch task.