### PR TITLE
implement .observe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+
+
 ## 0.7.11
 
 * More robust invalidation ([#42](https://github.com/gobblejs/gobble/issues/42))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble",
   "description": "The last build tool you'll ever need",
-  "version": "0.7.11",
+  "version": "0.8.0-edge",
   "author": "Rich Harris",
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble",

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -174,15 +174,15 @@ export default class Node extends EventEmitter2 {
 	}
 
 	observe ( fn, userOptions ) {
-		if ( userOptions && '__condition' in userOptions && !userOptions.__condition ) {
-			return this;
-		}
-
 		if ( typeof fn === 'string' ) {
 			fn = tryToLoad( fn );
 		}
 
 		return new Observer( this, fn, userOptions );
+	}
+
+	observeIf ( condition, fn, userOptions ) {
+		return condition ? this.observe( fn, userOptions ) : this;
 	}
 
 	serve ( options ) {
@@ -211,6 +211,10 @@ export default class Node extends EventEmitter2 {
 
 		// Otherwise it's a directory transformer
 		return new Transformer( this, fn, userOptions );
+	}
+
+	transformIf ( condition, fn, userOptions ) {
+		return condition ? this.transform( fn, userOptions ) : this;
 	}
 
 	watch ( options ) {

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -1,9 +1,10 @@
 import { EventEmitter2 } from 'eventemitter2';
-import { rimraf } from 'sander';
+import * as crc32 from 'buffer-crc32';
+import { lsrSync, readFileSync, rimraf } from 'sander';
 import { join, resolve } from 'path';
 import * as requireRelative from 'require-relative';
 import { grab, include, map as mapTransform, move } from '../builtins';
-import { Transformer } from './index';
+import { Observer, Transformer } from './index';
 import config from '../config';
 import GobbleError from '../utils/GobbleError';
 import assign from '../utils/assign';
@@ -108,6 +109,38 @@ export default class Node extends EventEmitter2 {
 		return new Transformer( this, include, { patterns, exclude: true });
 	}
 
+	getChanges ( inputdir ) {
+		const files = lsrSync( inputdir );
+
+		if ( !this._files ) {
+			this._files = files;
+			this._checksums = {};
+
+			files.forEach( file => {
+				this._checksums[ file ] = crc32( readFileSync( inputdir, file ) );
+			});
+
+			return files.map( file => ({ file, added: true }) );
+		}
+
+		const added = files.filter( file => !~this._files.indexOf( file ) ).map( file => ({ file, added: true }) );
+		const removed = this._files.filter( file => !~files.indexOf( file ) ).map( file => ({ file, removed: true }) );
+
+		const maybeChanged = files.filter( file => ~this._files.indexOf( file ) );
+
+		let changed = [];
+
+		maybeChanged.forEach( file => {
+			let checksum = crc32( readFileSync( inputdir, file ) );
+			if ( checksum !== this._checksums[ file ] ) {
+				changed.push({ file, changed: true });
+				this._checksums[ file ] = checksum;
+			}
+		});
+
+		return added.concat( removed ).concat( changed );
+	}
+
 	grab () {
 		const src = join.apply( null, arguments );
 		return new Transformer( this, grab, { src });
@@ -138,6 +171,18 @@ export default class Node extends EventEmitter2 {
 	moveTo () {
 		const dest = join.apply( null, arguments );
 		return new Transformer( this, move, { dest });
+	}
+
+	observe ( fn, userOptions ) {
+		if ( userOptions && '__condition' in userOptions && !userOptions.__condition ) {
+			return this;
+		}
+
+		if ( typeof fn === 'string' ) {
+			fn = tryToLoad( fn );
+		}
+
+		return new Observer( this, fn, userOptions );
 	}
 
 	serve ( options ) {

--- a/src/nodes/Observer.js
+++ b/src/nodes/Observer.js
@@ -1,0 +1,138 @@
+import * as sander from 'sander';
+import Node from './Node';
+import queue from '../queue';
+import GobbleError from '../utils/GobbleError';
+import assign from '../utils/assign';
+import uid from '../utils/uid';
+import makeLog from '../utils/makeLog';
+import config from '../config';
+import extractLocationInfo from '../utils/extractLocationInfo';
+import { ABORTED } from '../utils/signals';
+
+export default class Observer extends Node {
+	constructor ( input, fn, options, id ) {
+		super();
+
+		this.input = input;
+
+		this.fn = fn;
+		this.options = assign( {}, options );
+
+		this.name = id || fn.id || fn.name || 'unknown';
+		this.id = uid( this.name );
+	}
+
+	ready () {
+		let observation;
+
+		if ( !this._ready ) {
+			observation = {
+				node: this,
+				log: makeLog( this ),
+				env: config.env,
+				sander: sander
+			};
+
+			this._abort = () => {
+				this._ready = null;
+				observation.aborted = true;
+			};
+
+			this._ready = this.input.ready().then( inputdir => {
+				return queue.add( ( fulfil, reject ) => {
+					this.emit( 'info', {
+						code: 'TRANSFORM_START', // TODO
+						progressIndicator: true,
+						id: this.id
+					});
+
+					const start = Date.now();
+					let called = false;
+
+					const callback = err => {
+						if ( called ) return;
+						called = true;
+
+						if ( observation.aborted ) {
+							reject( ABORTED );
+						}
+
+						else if ( err ) {
+							let stack = err.stack || new Error().stack;
+							let { file, line, column } = extractLocationInfo( err );
+
+							let gobbleError = new GobbleError({
+								inputdir,
+								stack, file, line, column,
+								message: 'observation failed',
+								id: this.id,
+								code: 'TRANSFORMATION_FAILED', // TODO
+								original: err
+							});
+
+							reject( gobbleError );
+						}
+
+						else {
+							this.emit( 'info', {
+								code: 'TRANSFORM_COMPLETE', // TODO
+								id: this.id,
+								duration: Date.now() - start
+							});
+
+							fulfil( inputdir );
+						}
+					};
+
+					try {
+						observation.changes = this.input.changes || this.getChanges( inputdir );
+
+						const promise = this.fn.call( observation, inputdir, assign({}, this.options ), callback );
+						const promiseIsPromise = promise && typeof promise.then === 'function';
+
+						if ( !promiseIsPromise && this.fn.length < 3 ) {
+							throw new Error( `Observer ${this.id} did not return a promise and did not accept callback` );
+						}
+
+						if ( promiseIsPromise ) {
+							promise.then( () => callback(), callback );
+						}
+					} catch ( err ) {
+						callback( err );
+					}
+				});
+			});
+		}
+
+		return this._ready;
+	}
+
+	start () {
+		if ( this._active ) {
+			return;
+		}
+
+		this._active = true;
+
+		// Propagate invalidation events and information
+		this._oninvalidate = changes => {
+			this._abort();
+			this.emit( 'invalidate', changes );
+		};
+
+		this._oninfo = details => this.emit( 'info', details );
+
+		this.input.on( 'invalidate', this._oninvalidate );
+		this.input.on( 'info', this._oninfo );
+
+		return this.input.start();
+	}
+
+	stop () {
+		this.input.off( 'invalidate', this._oninvalidate );
+		this.input.off( 'info', this._oninfo );
+
+		this.input.stop();
+		this._active = false;
+	}
+}

--- a/src/nodes/Transformer.js
+++ b/src/nodes/Transformer.js
@@ -152,38 +152,6 @@ export default class Transformer extends Node {
 		this._active = false;
 	}
 
-	getChanges ( inputdir ) {
-		const files = lsrSync( inputdir );
-
-		if ( !this._files ) {
-			this._files = files;
-			this._checksums = {};
-
-			files.forEach( file => {
-				this._checksums[ file ] = crc32( readFileSync( inputdir, file ) );
-			});
-
-			return files.map( file => ({ file, added: true }) );
-		}
-
-		const added = files.filter( file => !~this._files.indexOf( file ) ).map( file => ({ file, added: true }) );
-		const removed = this._files.filter( file => !~files.indexOf( file ) ).map( file => ({ file, removed: true }) );
-
-		const maybeChanged = files.filter( file => ~this._files.indexOf( file ) );
-
-		let changed = [];
-
-		maybeChanged.forEach( file => {
-			let checksum = crc32( readFileSync( inputdir, file ) );
-			if ( checksum !== this._checksums[ file ] ) {
-				changed.push({ file, changed: true });
-				this._checksums[ file ] = checksum;
-			}
-		});
-
-		return added.concat( removed ).concat( changed );
-	}
-
 	_cleanup ( latest ) {
 		const dir = join( session.config.gobbledir, this.id );
 

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -1,5 +1,6 @@
 import Source from './Source';
 import Merger from './Merger';
+import Observer from './Observer';
 import Transformer from './Transformer';
 
-export { Source, Merger, Transformer };
+export { Source, Merger, Observer, Transformer };

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -634,16 +634,14 @@ module.exports = function () {
 				});
 		});
 
-		it( 'skips an observer if __condition is false', function () {
+		it( 'skips an observer if condition is false', function () {
 			var observed = 0;
 
 			function incrementObservedCount () {
 				observed += 1;
 			}
 
-			var source = gobble( 'tmp/foo' ).observe( incrementObservedCount, {
-				__condition: false
-			});
+			var source = gobble( 'tmp/foo' ).observeIf( false, incrementObservedCount );
 
 			task = source.build({
 				dest: 'tmp/output'
@@ -652,6 +650,24 @@ module.exports = function () {
 			return task.then( function () {
 				assert.equal( observed, 0 );
 			});
+		});
+
+		it( 'skips a transformer if condition is false', function () {
+			var source = gobble( 'tmp/foo' );
+
+			return source
+				.transformIf( false, function ( input ) {
+					return input.toUpperCase();
+				})
+				.build({
+					dest: 'tmp/output'
+				})
+				.then( function () {
+					assert.equal(
+						sander.readFileSync( 'tmp/foo/foo.md' ).toString(),
+						sander.readFileSync( 'tmp/output/foo.md' ).toString()
+					);
+				})
 		});
 	});
 

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -5,6 +5,8 @@ var gobble = require( '../tmp' ).default;
 var sander = require( 'sander' );
 var simulateChange = require( './utils/simulateChange' );
 
+var Promise = sander.Promise;
+
 gobble.cwd( __dirname );
 
 module.exports = function () {
@@ -509,6 +511,147 @@ module.exports = function () {
 			});
 
 			task.on( 'error', done );
+		});
+
+		it( 'calls observers on initial build', function () {
+			var observed = 0;
+
+			var source = gobble( 'tmp/foo' ).observe( function ( inputdir, options, done ) {
+				observed += 1;
+				done();
+			});
+
+			task = source.build({
+				dest: 'tmp/output'
+			});
+
+			return task.then( function () {
+				assert.equal( observed, 1 );
+			});
+		});
+
+		it( 'triggers observers on file changes', function ( done ) {
+			var observed = 0;
+
+			var source = gobble( 'tmp/foo' );
+
+			task = source.observe( function ( inputdir, options, done ) {
+				observed += 1;
+				done();
+			}).watch({
+				dest: 'tmp/output'
+			});
+
+			task.once( 'built', function () {
+				assert.equal( observed, 1 );
+
+				task.once( 'built', function () {
+					assert.equal( observed, 2 );
+					done();
+				});
+
+				simulateChange( source, {
+					type: 'change',
+					path: 'tmp/foo/foo.md'
+				});
+			});
+		});
+
+		it( 'prevents build completing if observers error', function () {
+			var source = gobble( 'tmp/foo' );
+			var error, threw;
+
+			var node = source
+				.observe( function () {
+					error = new Error( 'oh noes!' );
+					throw error;
+				});
+
+			return node.build({
+				dest: 'tmp/output'
+			})
+				.catch( function ( err ) {
+					if ( err.original == error ) {
+						threw = true;
+					} else {
+						throw err;
+					}
+				})
+				.then( function () {
+					assert.ok( threw );
+				});
+		});
+
+		it( 'prevents build completing if observers fail asynchronously via callback', function () {
+			var source = gobble( 'tmp/foo' );
+			var error, threw;
+
+			var node = source
+				.observe( function ( inputdir, options, done ) {
+					error = new Error( 'oh noes!' );
+					setTimeout( function () {
+						done( error );
+					});
+				});
+
+			return node.build({
+				dest: 'tmp/output'
+			})
+				.catch( function ( err ) {
+					if ( err.original == error ) {
+						threw = true;
+					} else {
+						throw err;
+					}
+				})
+				.then( function () {
+					assert.ok( threw );
+				});
+		});
+
+		it( 'prevents build completing if observers fail asynchronously via promise', function () {
+			var source = gobble( 'tmp/foo' );
+			var error, threw;
+
+			var node = source
+				.observe( function () {
+					error = new Error( 'oh noes!' );
+					return Promise.reject( error );
+				});
+
+			return node.build({
+				dest: 'tmp/output'
+			})
+				.catch( function ( err ) {
+					if ( err.original == error ) {
+						threw = true;
+					} else {
+						throw err;
+					}
+				})
+				.then( function () {
+					assert.ok( threw );
+				});
+		});
+
+		it( 'skips an observer if __condition is false', function () {
+			var observed = 0;
+
+			function incrementObservedCount () {
+				observed += 1;
+			}
+
+			var source = gobble( 'tmp/foo' ).observe( incrementObservedCount, {
+				__condition: false
+			});
+
+			task = source.build({
+				dest: 'tmp/output'
+			});
+
+			return task.then( function () {
+				assert.equal( observed, 0 );
+			});
 		});
 	});
 


### PR DESCRIPTION
Thought I'd have a quick crack at something talked about previously on #31, #34 and https://github.com/gobblejs/gobble/pull/28#issuecomment-81421924 - giving each node an `.observe()` method that gets called when its input successfully builds, in order to do things like linting, style checking, tests, writing intermediate stages to disk for inspection, etc etc etc.

It doesn't make any progress towards the design outlined by @evs-chris in https://github.com/gobblejs/gobble/pull/28#issuecomment-81421924 - for example transformations aren't expressed in terms of observers, so there's a bit of duplication that would be unnecessary with a better architecture. My thinking is that we can hone the API through use first and improve the implementation later.

Example using [gobble-eslint](https://github.com/gobblejs/gobble-eslint):

```js
es5 = gobble( 'src' )
	.transform( 'babel', {
		whitelist: babelTransformWhitelist
	})
	.observe( 'eslint', {
		reportOnly: true // won't fail the build
	});
```

This lints code *after* it's been transformed by babel. That's useful because it means you can prevent things like IIFEs in for loops, which can easily happen if you use block binding, even if the original code is perfectly valid. It outputs something like this:

![screen shot 2015-04-04 at 1 47 48 pm](https://cloud.githubusercontent.com/assets/1162160/6993871/a26dda00-dad1-11e4-8bd0-f84a6eab74b9.png)

Couple of points:

* It's likely that some tasks would only be relevant in certain situations. At the moment, if the options object has `__condition: false`, then `node.observe(fn, options) === node` - i.e. it gets skipped. [Example on eslint](https://github.com/gobblejs/gobble-eslint#usage). Does that make sense, or is it a bit weird?
* The ideal scenario would be that only changed files get linted (or whatever). At the moment that's tricky, because gobble's change detection is somewhat naive - if a sourcemap-generating file transformation gets re-run, *all* the files are deemed to have changed because the `sourceMappingURL` location gets bumped, even if the contents haven't changed.
* On a related note, one of the proposed uses for this API is rerunning unit tests only when needed. Even if the change detection were more robust, this is tricky because we need to know which modules each test file depends on, and determine whether *they* have changed. This likely isn't a problem to solve.

Any feedback welcome!