### PR TITLE
Update SOURCEMAP_COMMENT regexp

### DIFF
--- a/src/builtins/map.js
+++ b/src/builtins/map.js
@@ -9,7 +9,7 @@ import extractLocationInfo from '../utils/extractLocationInfo';
 import { isRegExp } from '../utils/is';
 import { ABORTED } from '../utils/signals';
 
-const SOURCEMAP_COMMENT = /\/\/#\s*sourceMappingURL=([^\s]+)/;
+const SOURCEMAP_COMMENT = /\/\/#\s*sourceMappingURL=([^\r\n]+)/;
 
 export default function map ( inputdir, outputdir, options ) {
 	let changed = {};


### PR DESCRIPTION
A quick fix for the same problem as Rich-Harris/sorcery#6. Currently, gobble removes only part of the comment, which results in completely broken file.

On a side note, gobble should be escaping generated URIs as well.