### PR TITLE
Make build build again? (plus some)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import * as sander from 'sander';
 import getNode from './utils/getNode';
 import config from './config';
 
-var gobble = ( inputs, options ) => getNode( inputs, options );
+var gobble = ( ...parts ) => getNode( parts );
 
 gobble.env = function ( env ) {
 	if ( arguments.length ) {

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -14,7 +14,8 @@ import compareBuffers from '../utils/compareBuffers';
 import serve from './serve';
 import build from './build';
 import watch from './watch';
-import { isRegExp } from '../utils/is';
+import { isRegExp, isString } from '../utils/is';
+import argsAndOpts from '../utils/argsAndOpts';
 import { ABORTED } from '../utils/signals';
 
 export default class Node extends EventEmitter2 {
@@ -109,9 +110,11 @@ export default class Node extends EventEmitter2 {
 		return watchTask;
 	}
 
-	exclude ( patterns ) {
-		if ( typeof patterns === 'string' ) { patterns = [ patterns ]; }
-		return new Transformer( this, include, { patterns, exclude: true });
+	exclude ( ...parts ) {
+		let [ patterns, opts ] = argsAndOpts( parts, true );
+		opts.patterns = patterns;
+		opts.exclude = true;
+		return new Transformer( this, include, opts );
 	}
 
 	getChanges ( inputdir ) {
@@ -147,15 +150,17 @@ export default class Node extends EventEmitter2 {
 		return added.concat( removed ).concat( changed );
 	}
 
-	grab () {
-		const src = join.apply( null, arguments );
-		return new Transformer( this, grab, { src });
+	grab ( ...parts ) {
+		let [ path, opts ] = argsAndOpts( parts );
+		opts.src = join.apply( null, path );
+		return new Transformer( this, grab, opts );
 	}
 
 	// Built-in transformers
-	include ( patterns ) {
-		if ( typeof patterns === 'string' ) { patterns = [ patterns ]; }
-		return new Transformer( this, include, { patterns });
+	include ( ...parts ) {
+		let [ patterns, opts ] = argsAndOpts( parts, true );
+		opts.patterns = patterns;
+		return new Transformer( this, include, opts );
 	}
 
 	inspect ( target, options ) {
@@ -174,13 +179,14 @@ export default class Node extends EventEmitter2 {
 		return this.transform( fn, userOptions );
 	}
 
-	moveTo () {
-		const dest = join.apply( null, arguments );
-		return new Transformer( this, move, { dest });
+	moveTo ( ...parts ) {
+		let [ path, opts ] = argsAndOpts( parts );
+		opts.dest = join.apply( null, path );
+		return new Transformer( this, move, opts );
 	}
 
 	observe ( fn, userOptions ) {
-		if ( typeof fn === 'string' ) {
+		if ( isString( fn ) ) {
 			fn = tryToLoad( fn );
 		}
 

--- a/src/nodes/build/index.js
+++ b/src/nodes/build/index.js
@@ -1,6 +1,5 @@
 import { resolve } from 'path';
-import { copydir, lsr ,readdir, Promise } from 'sander';
-import * as sorcery from 'sorcery';
+import { copydir, readdir } from 'sander';
 import cleanup from '../../utils/cleanup';
 import session from '../../session';
 import GobbleError from '../../utils/GobbleError';

--- a/src/utils/argsAndOpts.js
+++ b/src/utils/argsAndOpts.js
@@ -1,6 +1,6 @@
-import { isArray, isObject } from './is';
+import { isArray, isObject, isFunction } from './is';
 
-export default function( array, flatten = false ) {
+export default function( array, flatten = false, isOptions = null ) {
 	if ( !isArray( array ) ) { array = [ array ]; }
 
 	if ( array.length === 1 ) {
@@ -10,10 +10,10 @@ export default function( array, flatten = false ) {
 		return [ array, {} ];
 	}
 
-	let opts = array.slice( -1 );
+	let opts = array.slice( -1 )[0];
 	let args = array.slice( 0, -1 );
 
-	if ( !isObject( opts ) ) {
+	if ( !isObject( opts ) || ( isFunction( isOptions ) && !isOptions( opts ) ) ) {
 		args.push( opts );
 		opts = {};
 	}

--- a/src/utils/argsAndOpts.js
+++ b/src/utils/argsAndOpts.js
@@ -1,0 +1,26 @@
+import { isArray, isObject } from './is';
+
+export default function( array, flatten = false ) {
+	if ( !isArray( array ) ) { array = [ array ]; }
+
+	if ( array.length === 1 ) {
+		if ( flatten ) {
+			array = Array.prototype.concat.apply( [], array );
+		}
+		return [ array, {} ];
+	}
+
+	let opts = array.slice( -1 );
+	let args = array.slice( 0, -1 );
+
+	if ( !isObject( opts ) ) {
+		args.push( opts );
+		opts = {};
+	}
+
+	if ( flatten ) {
+		args = Array.prototype.concat.apply( [], args );
+	}
+
+	return [ args, opts ];
+}

--- a/src/utils/getNode.js
+++ b/src/utils/getNode.js
@@ -10,7 +10,7 @@ let sources = {};
 export default getNode;
 
 function getNode ( parts ) {
-	let [ inputs, options ] = argsAndOpts( parts, true );
+	let [ inputs, options ] = argsAndOpts( parts, true, obj => !obj._gobble );
 
 	if ( inputs.length === 1 ) {
 		if ( inputs[0]._gobble ) {

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -15,3 +15,7 @@ export function isString ( thing ) {
 export function isObject( thing ) {
 	return typeof thing === 'object';
 }
+
+export function isFunction( thing ) {
+	return typeof thing === 'function';
+}

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -11,3 +11,7 @@ export function isArray( thing ) {
 export function isString ( thing ) {
 	return typeof thing === 'string';
 }
+
+export function isObject( thing ) {
+	return typeof thing === 'object';
+}

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -557,6 +557,8 @@ module.exports = function () {
 
 			var source = gobble( 'tmp/foo' );
 
+			this.timeout( 5000 );
+
 			task = source.observe( function ( inputdir, options, done ) {
 				observed += 1;
 				done();

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -267,7 +267,7 @@ module.exports = function () {
 
 				source = gobble( 'tmp/foo' );
 
-				task = gobble([ source, source ]).serve();
+				task = gobble( source, source ).serve();
 
 				task.once( 'ready', function () {
 					task.once( 'built', function () {


### PR DESCRIPTION
I don't know if it's something I did wrong locally, but build ceased working for me for a few reasons, the first of which was a short bout of dependency hell (staleness; not related to the first commit here that adds the source-map-support dep).

The main problem seemed to stem from the source node not kicking off when the build started. Once that clears, I found that flattening sourcemaps kills the build for me because I have some external dependencies that are getting `concat`ed and uglified that don't have the referenced map sitting next to them. So, for now at least, I figured it was better to toss the error to the console and roll on with the build.

My build is an extra-funky 49 stages, since there are client, server, and shared sources of various types that get copied about and transformed. That makes figuring out which `moveTo` or `merge` path goes where a little tricky, so I added the option to supply an `id` to built-ins to make them a little easier to track down. I also applied the same logic to the main gobble export to allow multiple nodes to be supplied without passing them explicitly as an array because I keep face-palming when I can't figure out why a stage that I just added some more source to (the second node for the stage, of course) doesn't seem to work.

So, this gets build working for me again. There is a related PR incoming for the cli. If the fixes here are correct but you don't like API additions, please feel free to cherry-pick 'em. I added them for debugging and thought they might be nice enough to let them hang around.