### PR TITLE
Resolve original sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble",
   "dependencies": {
-    "buffer-crc32": "~0.2.3",
     "chalk": "^1.0.0",
+    "crc": "^3.2.1",
     "debounce": "^1.0.0",
     "eventemitter2": "^0.4.14",
     "findup-sync": "~0.1.3",
@@ -22,7 +22,7 @@
     "resolve": "^1.0.0",
     "rimraf": "~2.2.8",
     "sander": "^0.3.2",
-    "sorcery": "^0.5.4",
+    "sorcery": "^0.5.5",
     "source-map-support": "^0.2.10",
     "tiny-lr": "~0.1.0"
   },
@@ -43,8 +43,9 @@
     "source-map": "^0.4.2"
   },
   "scripts": {
-    "prepublish": "set -e; npm run build",
-    "test": "sh ./scripts/test.sh",
-    "build": "set -e; npm test; rm -rf lib; cp -r tmp lib"
+    "prepublish": "npm test",
+    "test": "mocha test/test.js",
+    "pretest": "npm run build",
+    "build": "sh ./scripts/build.sh"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+rm -rf lib
+
 echo "babel..."
 babel src --out-dir .babel -b es6.modules,useStrict --source-maps-inline --loose es6.classes > /dev/null
 
@@ -9,10 +11,7 @@ echo "esperanto..."
 esperanto -i .babel -o .esperanto -m inline -t cjs -s
 
 echo "sorcery"
-sorcery -i .esperanto -o tmp
-
-echo "mocha..."
-mocha test/test.js
+sorcery -i .esperanto -o lib
 
 rm -rf .babel
 rm -rf .esperanto

--- a/src/nodes/Merger.js
+++ b/src/nodes/Merger.js
@@ -104,7 +104,7 @@ export default class Merger extends Node {
 				let start;
 				let inputdirs = [];
 
-				return Promise.all( this.inputs.map( x => x.ready() ) )
+				return mapSeries( this.inputs, x => x.ready() )
 					.then( inputdirs => {
 						start = Date.now();
 

--- a/src/nodes/Merger.js
+++ b/src/nodes/Merger.js
@@ -85,6 +85,17 @@ export default class Merger extends Node {
 		});
 	}
 
+	getFileFromChecksum ( checksum ) {
+		let i = this.inputs.length;
+		let file;
+
+		while ( i-- ) {
+			if ( file = this.inputs[i].getFileFromChecksum( checksum ) ) {
+				return file;
+			}
+		}
+	}
+
 	ready () {
 		let aborted;
 		let index;
@@ -102,7 +113,6 @@ export default class Merger extends Node {
 
 			this._ready = mkdir( outputdir ).then( () => {
 				let start;
-				let inputdirs = [];
 
 				return mapSeries( this.inputs, x => x.ready() )
 					.then( inputdirs => {

--- a/src/nodes/Node.js
+++ b/src/nodes/Node.js
@@ -100,9 +100,9 @@ export default class Node extends EventEmitter2 {
 			}
 		}
 
-		watchTask.close = () => node.stop();
+		watchTask.close = () => node.stopFileWatcher();
 
-		this.start();
+		this.startFileWatcher();
 		process.nextTick( build );
 
 		return watchTask;

--- a/src/nodes/Observer.js
+++ b/src/nodes/Observer.js
@@ -20,6 +20,17 @@ export default class Observer extends Node {
 
 		this.name = id || fn.id || fn.name || 'unknown';
 		this.id = uid( this.name );
+
+		// Propagate invalidation events and information
+		this._oninvalidate = changes => {
+			this._abort();
+			this.emit( 'invalidate', changes );
+		};
+
+		this._oninfo = details => this.emit( 'info', details );
+
+		this.input.on( 'invalidate', this._oninvalidate );
+		this.input.on( 'info', this._oninfo );
 	}
 
 	ready () {
@@ -107,36 +118,17 @@ export default class Observer extends Node {
 		return this._ready;
 	}
 
-	start () {
-		if ( this._active ) {
-			return;
-		}
-
-		this._active = true;
-
-		// Propagate invalidation events and information
-		this._oninvalidate = changes => {
-			this._abort();
-			this.emit( 'invalidate', changes );
-		};
-
-		this._oninfo = details => this.emit( 'info', details );
-
-		this.input.on( 'invalidate', this._oninvalidate );
-		this.input.on( 'info', this._oninfo );
-
-		return this.input.start();
+	startFileWatcher () {
+		this.input.startFileWatcher();
 	}
 
-	stop () {
+	stopFileWatcher () {
+		this.input.stopFileWatcher();
+	}
+
+	teardown () {
 		this.input.off( 'invalidate', this._oninvalidate );
 		this.input.off( 'info', this._oninfo );
-
-		this.input.stop();
-		this._active = false;
-	}
-
-	active () {
-		return this._active;
+		this.input.teardown();
 	}
 }

--- a/src/nodes/Observer.js
+++ b/src/nodes/Observer.js
@@ -33,6 +33,10 @@ export default class Observer extends Node {
 		this.input.on( 'info', this._oninfo );
 	}
 
+	getFileFromChecksum ( checksum ) {
+		return this.input.getFileFromChecksum( checksum );
+	}
+
 	ready () {
 		let observation;
 

--- a/src/nodes/Source.js
+++ b/src/nodes/Source.js
@@ -50,7 +50,7 @@ export default class Source extends Node {
 		return this._ready;
 	}
 
-	start () {
+	startFileWatcher () {
 		if ( this._active || this.static ) {
 			return;
 		}
@@ -110,7 +110,7 @@ export default class Source extends Node {
 		}
 	}
 
-	stop () {
+	stopFileWatcher () {
 		if ( this._watcher ) {
 			this._watcher.close();
 		}
@@ -122,8 +122,8 @@ export default class Source extends Node {
 		this._active = false;
 	}
 
-	active () {
-		return this._active;
+	teardown () {
+		// noop
 	}
 
 	_findCreator ( filename ) {

--- a/src/nodes/Source.js
+++ b/src/nodes/Source.js
@@ -52,12 +52,6 @@ export default class Source extends Node {
 			this._ready = queue.add( ( fulfil, reject ) => {
 				const start = Date.now();
 
-				this.emit( 'info', {
-					code: 'CHECKSUM_START',
-					progressIndicator: true,
-					dir: this.dir
-				});
-
 				this._makeReady();
 
 				lsr( this.dir )
@@ -70,11 +64,12 @@ export default class Source extends Node {
 							this.checksumByFile[ absolutePath ] = checksum;
 							this.fileByChecksum[ checksum ] = absolutePath;
 						});
-						this.emit( 'info', {
-							code: 'CHECKSUM_COMPLETE',
-							duration: Date.now() - start,
-							dir: this.dir
-						});
+
+						// If
+						const duration = Date.now() - start;
+						if ( duration > 200 ) {
+							this.emit( 'info', `the ${this.dir} directory took ${duration}ms to initialise - consider excluding unnecessary files from the build` );
+						}
 					})
 					.then( () => fulfil( this.dir ) )
 					.catch( reject );

--- a/src/nodes/Transformer.js
+++ b/src/nodes/Transformer.js
@@ -46,6 +46,10 @@ export default class Transformer extends Node {
 		this.input.on( 'info', this._oninfo );
 	}
 
+	getFileFromChecksum ( checksum ) {
+		return this.input.getFileFromChecksum( checksum );
+	}
+
 	ready () {
 		let outputdir;
 		let transformation;

--- a/src/nodes/build/index.js
+++ b/src/nodes/build/index.js
@@ -35,7 +35,7 @@ export default function ( node, options ) {
 		return node.ready()
 			.then( inputdir => {
 				return copydir( inputdir ).to( dest )
-					.then( () => flattenSourcemaps( inputdir, dest, dest, task ) );
+					.then( () => flattenSourcemaps( node, inputdir, dest, dest, task ) );
 			})
 			.then( () => {
 				node.teardown();

--- a/src/nodes/build/index.js
+++ b/src/nodes/build/index.js
@@ -25,7 +25,6 @@ export default function ( node, options ) {
 		task.emit( 'info', {
 			code: 'BUILD_START'
 		});
-		node.start();
 
 		node.on( 'info', details => {
 			if ( details === previousDetails ) return;
@@ -38,7 +37,9 @@ export default function ( node, options ) {
 				return copydir( inputdir ).to( dest )
 					.then( () => flattenSourcemaps( inputdir, dest, dest, task ) );
 			})
-			.then( () => node.stop() ); // TODO should not need to stop...
+			.then( () => {
+				node.teardown();
+			});
 	}
 
 	promise = cleanup( gobbledir )

--- a/src/nodes/serve/handleRequest.js
+++ b/src/nodes/serve/handleRequest.js
@@ -6,7 +6,7 @@ import serveDir from './serveDir';
 import serveSourcemap from './serveSourcemap';
 import serveError from './serveError';
 
-export default function handleRequest ( srcDir, error, sourcemapPromises, request, response ) {
+export default function handleRequest ( node, srcDir, error, sourcemapPromises, request, response ) {
 	const parsedUrl = parse( request.url );
 	const pathname = parsedUrl.pathname;
 
@@ -31,7 +31,7 @@ export default function handleRequest ( srcDir, error, sourcemapPromises, reques
 	filepath = join( srcDir, pathname );
 
 	if ( extname( filepath ) === '.map' ) {
-		return serveSourcemap( filepath, sourcemapPromises, request, response )
+		return serveSourcemap( node, filepath, sourcemapPromises, request, response )
 			.catch( err => serveError( err, request, response ) );
 	}
 

--- a/src/nodes/serve/index.js
+++ b/src/nodes/serve/index.js
@@ -66,8 +66,9 @@ export default function serve ( node, options = {} ) {
 	};
 
 	task.close = () => {
-		if ( node ) {
-			node.stop();
+		if ( watchTask ) {
+			watchTask.close();
+			node.teardown();
 		}
 
 		return new Promise( fulfil => {
@@ -82,8 +83,9 @@ export default function serve ( node, options = {} ) {
 
 		buildStarted = Date.now();
 
-		if ( node ) {
-			node.stop();
+		if ( watchTask ) {
+			watchTask.close();
+			node.teardown();
 		}
 
 		node = null;

--- a/src/nodes/serve/index.js
+++ b/src/nodes/serve/index.js
@@ -125,7 +125,7 @@ export default function serve ( node, options = {} ) {
 	});
 
 	server.on( 'request', ( request, response ) => {
-		handleRequest( srcDir, error, sourcemapPromises, request, response )
+		handleRequest( node, srcDir, error, sourcemapPromises, request, response )
 			.catch( err => task.emit( 'error', err ) );
 	});
 

--- a/src/nodes/serve/serveSourcemap.js
+++ b/src/nodes/serve/serveSourcemap.js
@@ -1,6 +1,9 @@
+import { crc32 } from 'crc';
+import { dirname, relative, resolve } from 'path';
+import { readFileSync } from 'sander';
 import { load } from 'sorcery';
 
-export default function serveSourcemap ( filepath, sourcemapPromises, request, response ) {
+export default function serveSourcemap ( node, filepath, sourcemapPromises, request, response ) {
 	const owner = filepath.slice( 0, -4 );
 
 	if ( !sourcemapPromises[ filepath ] ) {
@@ -10,7 +13,23 @@ export default function serveSourcemap ( filepath, sourcemapPromises, request, r
 					throw new Error( 'Could not resolve sourcemap for ' + owner );
 				}
 
-				return chain.apply().toString();
+				const map = chain.apply();
+				const dir = dirname( owner );
+				const cwd = process.cwd();
+
+				map.sources = map.sources.map( ( source, i ) => {
+					const content = map.sourcesContent[i];
+					const checksum = crc32( content );
+					const originalSource = node.getFileFromChecksum( checksum );
+
+					const absolutePath = resolve( dir, originalSource || source );
+
+					return relative( cwd, absolutePath );
+				});
+
+				map.sourceRoot = 'file://' + process.cwd();
+
+				return map.toString();
 			});
 	}
 

--- a/src/nodes/watch/index.js
+++ b/src/nodes/watch/index.js
@@ -40,7 +40,7 @@ export default function watch ( node, options ) {
 						progressIndicator: true
 					});
 
-					return flattenSourcemaps( dir, dest, dest, task ).then( () => {
+					return flattenSourcemaps( node, dir, dest, dest, task ).then( () => {
 						task.emit( 'info', {
 							code: 'SOURCEMAP_PROCESS_COMPLETE',
 							duration: Date.now() - sourcemapProcessStart

--- a/src/nodes/watch/index.js
+++ b/src/nodes/watch/index.js
@@ -60,6 +60,7 @@ export default function watch ( node, options ) {
 
 	task.close = () => {
 		watchTask.close();
+		node.teardown();
 		session.destroy();
 
 		return Promise.resolve(); // for consistency with serve task
@@ -68,6 +69,7 @@ export default function watch ( node, options ) {
 	task.pause = () => {
 		if ( watchTask ) {
 			watchTask.close();
+			node.teardown();
 		}
 
 		watchTask = null;

--- a/src/utils/flattenSourcemaps.js
+++ b/src/utils/flattenSourcemaps.js
@@ -1,11 +1,13 @@
-import { extname, resolve } from 'path';
-import { lsr } from 'sander';
+import { basename, dirname, extname, relative, resolve } from 'path';
+import { lsr, readFileSync, writeFile } from 'sander';
 import * as mapSeries from 'promise-map-series';
 import { load } from 'sorcery';
+import { crc32 } from 'crc';
+import { SOURCEMAP_COMMENT, getSourcemapComment } from './sourcemap';
 
 const whitelist = { '.js': true, '.css': true };
 
-export default function flattenSourcemaps ( inputdir, outputdir, base, task ) {
+export default function flattenSourcemaps ( node, inputdir, outputdir, base, task ) {
 	return lsr( inputdir ).then( files => {
 		const jsAndCss = files.filter( file => whitelist[ extname( file ) ] );
 
@@ -13,7 +15,23 @@ export default function flattenSourcemaps ( inputdir, outputdir, base, task ) {
 			return load( resolve( inputdir, file ) )
 				.then( chain => {
 					if ( chain ) {
-						return chain.write( resolve( outputdir, file ), { base });
+						const map = chain.apply({ base });
+
+						map.sources = map.sources.map( source => {
+							const checksum = crc32( readFileSync( base, source ) );
+							const originalSource = node.getFileFromChecksum( checksum );
+
+							const dir = dirname( resolve( base, file ) );
+							return originalSource ? relative( dir, originalSource ) : source;
+						});
+
+						const code = readFileSync( inputdir, file, { encoding: 'utf-8' })
+							.replace( SOURCEMAP_COMMENT, getSourcemapComment( encodeURI( basename( file + '.map' ) ), extname( file ) ) );
+
+						return Promise.all([
+							writeFile( outputdir, file, code ),
+							writeFile( outputdir, file + '.map', map.toString() )
+						]);
 					}
 				})
 				.catch( err => {

--- a/test/build.js
+++ b/test/build.js
@@ -1,7 +1,7 @@
 var assert = require( 'assert' ),
 	path = require( 'path' ),
 	sander = require( 'sander' ),
-	gobble = require( '../tmp' ).default;
+	gobble = require( '../lib' ).default;
 	sample = new RegExp( '^' + path.join( __dirname, 'sample' ) );
 
 module.exports = function () {

--- a/test/build.js
+++ b/test/build.js
@@ -26,20 +26,6 @@ module.exports = function () {
 			});
 		});
 
-		it( 'should stop completion of build', function () {
-			var node = gobble( 'tmp/foo' );
-			var task = node.build({
-				dest: 'tmp/output'
-			});
-			return task.then( function () {
-				assert.equal(node.active(), false);
-
-				return sander.readFile( 'tmp/output', 'foo.md' ).then( function ( data ) {
-					assert.equal( data.toString().trim(), 'foo: this is some text' );
-				});
-			});
-		});
-
 		it( 'should throw an error if no `dest` is specified', function () {
 			assert.throws( function () {
 				gobble( 'tmp/foo' ).build();

--- a/test/cleanup.js
+++ b/test/cleanup.js
@@ -1,7 +1,7 @@
 var assert = require( 'assert' );
 var path = require( 'path' );
 var request = require( 'request-promise' );
-var gobble = require( '../tmp' ).default;
+var gobble = require( '../lib' ).default;
 var sander = require( 'sander' );
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 var simulateChange = require( './utils/simulateChange' );

--- a/test/env.js
+++ b/test/env.js
@@ -1,5 +1,5 @@
 var assert = require( 'assert' ),
-	gobble = require( '../tmp' ).default;
+	gobble = require( '../lib' ).default;
 
 module.exports = function () {
 	describe( 'gobble.env()', function () {
@@ -22,7 +22,7 @@ module.exports = function () {
 
 			process.env.GOBBLE_ENV = 'production';
 
-			gobble = require( '../tmp' ).default;
+			gobble = require( '../lib' ).default;
 			assert.equal( gobble.env(), 'production' );
 
 			Object.keys( require.cache ).forEach( function ( key ) {

--- a/test/initialisation.js
+++ b/test/initialisation.js
@@ -1,7 +1,7 @@
 var assert = require( 'assert' );
 var path = require( 'path' );
 var request = require( 'request-promise' );
-var gobble = require( '../tmp' ).default;
+var gobble = require( '../lib' ).default;
 var sander = require( 'sander' );
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 var simulateChange = require( './utils/simulateChange' );

--- a/test/sample/foo.js
+++ b/test/sample/foo.js
@@ -1,4 +1,4 @@
-var gobble = require( '../../tmp' ).default,
+var gobble = require( '../../lib' ).default,
 	path = require( 'path' );
 
 module.exports = gobble( path.join( __dirname, 'foo' ) );

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -1,7 +1,7 @@
 var assert = require( 'assert' );
 var path = require( 'path' );
 var request = require( 'request-promise' );
-var gobble = require( '../tmp' ).default;
+var gobble = require( '../lib' ).default;
 var sander = require( 'sander' );
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 var simulateChange = require( './utils/simulateChange' );

--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -145,7 +145,7 @@ module.exports = function () {
 
 			task.once( 'built', function () {
 				task.once( 'built', function () {
-					var content = sander.readFileSync( 'tmp/output/baz' );
+					var content = sander.readFileSync( 'tmp/output/baz' ).toString();
 					assert.equal( content, 'step2' );
 					done();
 				});
@@ -158,11 +158,7 @@ module.exports = function () {
 				});
 			});
 
-			task.on( 'error', function ( err ) {
-				setTimeout( function () {
-					throw err;
-				});
-			});
+			task.on( 'error', done );
 		});
 
 		it( 'does not use non-existent sourcemap files when reusing cached file transformer results', function ( done ) {
@@ -272,7 +268,7 @@ module.exports = function () {
 
 						sander.lsr( 'tmp/output' )
 							.then( function ( files ) {
-								assert.deepEqual( files, [ 'app.min.js', 'app.min.js.map' ].sort() );
+								assert.deepEqual( files.sort(), [ 'app.min.js', 'app.min.js.map' ].sort() );
 							})
 					]);
 				});


### PR DESCRIPTION
This fixes #69. It doesn't come entirely free - when you first run `gobble`, it has to read all the source files to generate checksums, which can take a couple of seconds if there are a lot of them, or they're very large (about 1500 milliseconds for 100Mb of images, on this machine, for example). But it's a one-off thing. If it becomes a source of pain we could mitigate it by perhaps doing it lazily, or excluding certain file types from the process, or some other trick.

I've just realised I based the branch off the `start-stop` branch, so it includes all of #74 as well. Oh well