### PR TITLE
Replacing hard link with symlink for single-file source nodes?

### DIFF
--- a/src/nodes/Source.js
+++ b/src/nodes/Source.js
@@ -1,5 +1,5 @@
 import { basename, relative, resolve } from 'path';
-import { link, linkSync, mkdirSync, statSync, Promise } from 'sander';
+import { symlinkOrCopy, symlinkOrCopySync, mkdirSync, statSync, Promise } from 'sander';
 import { watch } from 'graceful-chokidar';
 import * as debounce from 'debounce';
 import Node from './Node';
@@ -64,7 +64,7 @@ export default class Source extends Node {
 
 		// make sure the file is in the appropriate target directory to start
 		if ( this.file ) {
-			linkSync( this.file ).to( this.targetFile );
+			symlinkOrCopySync( this.file ).to( this.targetFile );
 		}
 
 		let changes = [];
@@ -105,7 +105,7 @@ export default class Source extends Node {
 			this._fileWatcher = watch( this.file, options );
 
 			this._fileWatcher.on( 'change', () => {
-				link( this.file ).to( this.targetFile );
+				symlinkOrCopy( this.file ).to( this.targetFile );
 			});
 		}
 	}


### PR DESCRIPTION
I expect it's rare for hard links to pose an issue, but I'm using AFS which doesn't support hard links across directories (http://www-01.ibm.com/support/docview.wss?uid=swg21047089) so Gobbling a file fails with an EXDEV error. Any chance we could use `symlinkOrCopy` instead of `link` for single-file source nodes instead? It looks like it's used elsewhere in Gobble and it doesn't seem to break the tests. 

No hard feelings if you'd rather keep the hard link though!