### PR TITLE
Bump deps & gracefully serve

### DIFF
--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -272,7 +272,7 @@ module.exports = function () {
 
 						sander.lsr( 'tmp/output' )
 							.then( function ( files ) {
-								assert.deepEqual( files, [ 'app.min.js', 'app.min.js.map' ].sort() );
+								assert.deepEqual( files.sort(), [ 'app.min.js', 'app.min.js.map' ].sort() );
 							})
 					]);
 				});


### PR DESCRIPTION
hi rich,

I really like gobble a lot. in fact, so much so, I have converted our platform to ractive / gobble over the weekend. it was a lot of work, but th fact that I could take a relatively large angular site and convert 80% of if to ractive over the weekend was what sold me on it. 

anyway, we have a few devs that run windows. gobble doesn't work with so many files. so, what I had to do, to get gobble working on windows for them was to bump graceful-fs up to 4.x - and then I needed to globally patch the fs module so that I could replace graceful-chokidar with chokidar vanilla.

I have split this update into 4 separate PRs:
(this one)
EDIT: I fucked up. I'm gonna combine and do just two...

global patching with gracefulify:
https://github.com/isaacs/node-graceful-fs/blob/master/README.md#global-patching

these PRs are tested on OSX and windows 7

cheers
