### PR TITLE
Pathwatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
   - "0.12"
   - "4"
 env:
-  global:
-    - BUILD_TIMEOUT=10000
+  - CC=clang CXX=clang++ npm_config_clang=1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "buffer-crc32": "~0.2.5",
     "chalk": "^1.1.1",
-    "chokidar": "^1.2.0",
     "debounce": "^1.0.0",
     "eventemitter2": "^0.4.14",
     "findup-sync": "~0.3.0",
@@ -17,6 +16,7 @@
     "mime": "^1.3.4",
     "minimatch": "~3.0.0",
     "mkdirp": "~0.5.1",
+    "pathwatcher": "^6.2.5",
     "promise-map-series": "~0.2.1",
     "require-relative": "~0.8.7",
     "resolve": "^1.1.6",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,4 +3,4 @@ set -e
 rm -rf dist
 mkdir -p dist
 
-rollupbabel -i src/index.js -o dist/gobble.js -f cjs -m -e path,chalk,sander,chokidar,debounce,promise-map-series,eventemitter2,buffer-crc32,require-relative,util,http,tiny-lr,minimatch,url,mime,graceful-fs
+rollupbabel -i src/index.js -o dist/gobble.js -f cjs -m -e path,chalk,sander,pathwatcher,debounce,promise-map-series,eventemitter2,buffer-crc32,require-relative,util,http,tiny-lr,minimatch,url,mime,graceful-fs

--- a/test/env.js
+++ b/test/env.js
@@ -16,6 +16,7 @@ module.exports = function () {
 			var tmpCache = {}, gobble;
 
 			Object.keys( require.cache ).forEach( function ( key ) {
+				if ( key.substr(-5) === '.node' ) return;
 				tmpCache[ key ] = require.cache[ key ];
 				delete require.cache[ key ];
 			});


### PR DESCRIPTION
hi @Rich-Harris 

I noticed the gobble process for our project (it has a lot of files) was using a shitload of cpu while idle. I looked into it and it was all the polling done by chokidar. the cpu was churning away on the 100 zillion files being watched/served by gobble. so, I decided I would upgrade chokidar to [pathwatcher](https://github.com/atom/node-pathwatcher). it's used in the atom editor and runs fine on windows, linux and osx.

so check this: after doing the conversion what was previously 3-7% constant cpu usage on the gobble process (once, up to 12% when I didn't restart the process for about a week) -- has now become literally zero. none. not one bit. I am not seeing such huge memory blowout over time either.

been testing this for a little while now and it's solid as a rock man.

super happy! cheers!