### PR TITLE
Update pathwatcher dependency to 6.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mime": "^1.3.4",
     "minimatch": "~3.0.0",
     "mkdirp": "~0.5.1",
-    "pathwatcher": "^6.2.5",
+    "pathwatcher": "^6.5.0",
     "promise-map-series": "~0.2.1",
     "require-relative": "~0.8.7",
     "resolve": "^1.1.6",


### PR DESCRIPTION
This is an alternative to #106, which aims to fix the same problem (high CPU usage in my linux box since upgrading to node 4.4)