### PR TITLE
Fix main field in package.json; → 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble",
   "description": "The last build tool you'll ever need",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "Rich Harris",
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble",
@@ -31,7 +31,7 @@
     "dist",
     "README.md"
   ],
-  "main": "dist/index.js",
+  "main": "dist/gobble.js",
   "keywords": [
     "gobble"
   ],


### PR DESCRIPTION
Fixes a build bug introduced in https://github.com/gobblejs/gobble/commit/18b7ffa79e30fbcd75113de1e09885f35700653c#diff-ff6e5f22a9c7e66987b19c0199636480R9 : the filename of the rolled-up file is now `gobble.js` instead of `index.js`.

This is making `gobble-cli` fail, as it cannot find the script pointed by the `main` field in gobble's `package.json`