### PR TITLE
Fix sourcemap comments to be used on file transformers with CSS output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Reject in promise instead of throwing MISSING_DEST_DIR
+* In file transformers, use the destination filename extension to decide the sourcemap comment style. ([#116](https://github.com/gobblejs/gobble/issues/116))
 
 ## 0.11.3
 

--- a/src/builtins/map.js
+++ b/src/builtins/map.js
@@ -109,7 +109,7 @@ function processResult ( result, original, src, dest, codepath ) {
 		// if a sourcemap was returned, use it
 		if ( result.map ) {
 			return {
-				code: result.code.replace( SOURCEMAP_COMMENT, '' ) + getSourcemapComment( encodeURI( codepath + '.map' ), extname( codepath ) ),
+				code: result.code.replace( SOURCEMAP_COMMENT, '' ) + getSourcemapComment( encodeURI( codepath + '.map' ), extname( dest ) ),
 				map: processSourcemap( result.map, src, dest, original )
 			};
 		}


### PR DESCRIPTION
This fixes a case where a file transformer (namely, `gobble-sass-all`) takes `.sass` files as input and `.css` files as output - the code was (wrongly) assuming that the input file extension decides which sourcemap comment style to use. In other words: my CSS files were being written a javascript-style sourcemap comment.