### PR TITLE
Source map URL Regex swallows UMD/IIFE globals code

### DIFF
--- a/src/nodes/serve/serveFile.js
+++ b/src/nodes/serve/serveFile.js
@@ -17,6 +17,7 @@ export default function serveFile ( filepath, request, response ) {
 
 			response.statusCode = 200;
 			response.setHeader( 'Content-Type', mime.lookup( filepath ) );
+
 			response.write( data );
 			response.end();
 		});

--- a/src/nodes/serve/serveFile.js
+++ b/src/nodes/serve/serveFile.js
@@ -12,7 +12,6 @@ export default function serveFile ( filepath, request, response ) {
 			// this takes the auto-generated absolute sourcemap path, and turns
 			// it into what you'd get with `gobble build` or `gobble watch`
 			const sourcemapComment = getSourcemapComment( basename( filepath ) + '.map', ext );
-			
 			data = data.toString().replace( SOURCEMAP_COMMENT, "" ) + sourcemapComment;
 
 			response.statusCode = 200;

--- a/src/nodes/serve/serveFile.js
+++ b/src/nodes/serve/serveFile.js
@@ -12,11 +12,12 @@ export default function serveFile ( filepath, request, response ) {
 			// this takes the auto-generated absolute sourcemap path, and turns
 			// it into what you'd get with `gobble build` or `gobble watch`
 			const sourcemapComment = getSourcemapComment( basename( filepath ) + '.map', ext );
-			data = data.toString().replace( SOURCEMAP_COMMENT, sourcemapComment );
+			
+			data = data.toString().replace( SOURCEMAP_COMMENT, "" ) + sourcemapComment;
 
 			response.statusCode = 200;
 			response.setHeader( 'Content-Type', mime.lookup( filepath ) );
-
+			
 			response.write( data );
 			response.end();
 		});

--- a/src/nodes/serve/serveFile.js
+++ b/src/nodes/serve/serveFile.js
@@ -17,7 +17,6 @@ export default function serveFile ( filepath, request, response ) {
 
 			response.statusCode = 200;
 			response.setHeader( 'Content-Type', mime.lookup( filepath ) );
-			
 			response.write( data );
 			response.end();
 		});

--- a/src/utils/sourcemap.js
+++ b/src/utils/sourcemap.js
@@ -2,9 +2,9 @@ let SOURCEMAPPING_URL = 'sourceMa';
 SOURCEMAPPING_URL += 'ppingURL';
 
 const SOURCEMAP_COMMENT = new RegExp( `\n*(?:` +
-	`\\/\\/[@#]\\s*${SOURCEMAPPING_URL}=([^'"]+)|` +      // js
-	`\\/\\*#?\\s*${SOURCEMAPPING_URL}=([^'"]+)\\s\\+\\/)` + // css
-'\\s*$', 'g' );
+	`\\/\\/[@#]\\s*${SOURCEMAPPING_URL}=([^'"]+?)|` +      // js
+	`\\/\\*#?\\s*${SOURCEMAPPING_URL}=([^'"]+?)\\s\\+\\/)` + // css
+'\\s*($|\n)', 'g' );
 
 function getSourcemapComment ( url, ext ) {
 	if ( ext === '.css' ) {


### PR DESCRIPTION
The regex in `sourcemap.js` appears to swallow the bottom half of a UMD/IIFE wrapper in some circumstances, when it is attempting to use globals. Like so:

<img width="909" alt="screen shot 2017-08-21 at 17 45 36" src="https://user-images.githubusercontent.com/732835/29540289-a6f161be-869b-11e7-97e4-955bfaf55b13.png">

I've made two changes:

1. Edited the regex to use a lazy quantifier, and to allow newline _or_ end of string at the end of the match.
2. Changed `serveFile.js` to replace all source map comments with an empty string, then append the comment at the end, rather than replace in-place. This is also what `map.js` does.

All the tests run, but I haven't been able to isolate exactly what causes this to create a new test of my own.